### PR TITLE
♻️  Add API key reset button to UI

### DIFF
--- a/src/common/App.tsx
+++ b/src/common/App.tsx
@@ -4,6 +4,7 @@ import { useAppState } from '../state/store';
 import ModelDropdown from './ModelDropdown';
 import SetAPIKey from './SetAPIKey';
 import TaskUI from './TaskUI';
+import OptionsDropdown from './OptionsDropdown';
 import logo from '../assets/img/icon-128.png';
 
 const App = () => {
@@ -24,9 +25,10 @@ const App = () => {
           <Heading as="h1" size="lg" flex={1}>
             Taxy AI
           </Heading>
-          <Box>
+          <HStack spacing={2}>
             <ModelDropdown />
-          </Box>
+            <OptionsDropdown />
+          </HStack>
         </HStack>
         {openAIKey ? <TaskUI /> : <SetAPIKey />}
       </Box>

--- a/src/common/OptionsDropdown.tsx
+++ b/src/common/OptionsDropdown.tsx
@@ -1,0 +1,42 @@
+import { RepeatIcon, SettingsIcon } from '@chakra-ui/icons';
+import {
+  IconButton,
+  Menu,
+  MenuButton,
+  MenuItem,
+  MenuList,
+} from '@chakra-ui/react';
+import React from 'react';
+import { useAppState } from '../state/store';
+
+const OptionsDropdown = () => {
+  const { openAIKey, updateSettings } = useAppState((state) => ({
+    openAIKey: state.settings.openAIKey,
+    updateSettings: state.settings.actions.update,
+  }));
+
+  if (!openAIKey) return null;
+
+  return (
+    <Menu>
+      <MenuButton
+        as={IconButton}
+        aria-label="Options"
+        icon={<SettingsIcon />}
+        variant="outline"
+      />
+      <MenuList>
+        <MenuItem
+          icon={<RepeatIcon />}
+          onClick={() => {
+            updateSettings({ openAIKey: '' });
+          }}
+        >
+          Reset API Key
+        </MenuItem>
+      </MenuList>
+    </Menu>
+  );
+};
+
+export default OptionsDropdown;


### PR DESCRIPTION
Allows the user to reset their API key.

This includes the addition of a Chakra menu button to put this less used functionality under. Allows additional options to be put inside this menu.

Commit messages generated by AI with [OpenCommit](https://github.com/di-sukharev/opencommit).

closes #3 